### PR TITLE
Deleted duplicate variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,6 @@ syslog_ng_config_options:
   bad_hostname: '"^gconfd$"'
   create_dirs: 'yes'
 
-syslog_ng_config_default_port: 514
 syslog_ng_check_syntax_before_reload: true
 
 syslog_ng_config_version_auto_detect: true


### PR DESCRIPTION
Ansible 2.0.1
[WARNING]: While constructing a mapping from /home/greenday/Work/git/pgsql-ha-example/roles/ihrwein.syslog-ng/defaults/main.yml, line 2, column 1, found a
duplicate dict key (syslog_ng_config_default_port).  Using last defined value only.